### PR TITLE
feat: implement global ticket system with role-based permissions

### DIFF
--- a/TICKETS-SISTEMA-GLOBAL.md
+++ b/TICKETS-SISTEMA-GLOBAL.md
@@ -1,0 +1,166 @@
+# Sistema de Tickets Global - Implementação
+
+## 🎯 Objetivo
+Tornar o sistema de tickets global, onde todos os usuários podem visualizar e criar tickets, mas apenas administradores podem alterar status.
+
+## 🔧 Mudanças Implementadas
+
+### 1. **Serviço Backend (`lib/tickets-service.ts`)**
+
+#### Visualização Global:
+```typescript
+// ANTES: Filtrava tickets por hotel para staff
+if (currentUser.role === 'staff' && currentUser.hotelId) {
+  if (ticket.createdBy?.hotelId !== currentUser.hotelId) {
+    return false;
+  }
+}
+
+// DEPOIS: Removido - todos veem todos os tickets
+// REMOVIDO: Filtro para staff - agora todos podem ver todos os tickets
+// Tickets são globais para melhor colaboração e transparência
+```
+
+#### Controle de Permissões para Mudança de Status:
+```typescript
+// NOVO: Verificação de admin para mudanças de status
+if (updateData.status && updateData.status !== currentTicket.status) {
+  if (currentUser.role !== 'admin') {
+    throw new Error('Apenas administradores podem alterar o status dos tickets');
+  }
+}
+```
+
+#### Funções Afetadas:
+- ✅ `getTickets()` - agora retorna todos os tickets para todos
+- ✅ `subscribeToTickets()` - listener global para todos os usuários  
+- ✅ `updateTicket()` - protegido para mudanças de status apenas por admins
+- ✅ `moveTicketToStatus()` - herda proteção do updateTicket
+
+### 2. **Interface Frontend**
+
+#### TicketBoard (`app/tickets/components/TicketBoard.tsx`):
+```typescript
+// Mensagem informativa para não-admins
+<p className="text-muted-foreground">
+  Gerencie problemas técnicos e solicitações da plataforma ExpiWish
+  {!isAdmin && " (Visualização - Somente admins podem alterar status)"}
+</p>
+
+// Drag and drop desabilitado para não-admins
+const handleDragEnd = useCallback((event: DragEndEvent) => {
+  if (!isAdmin) {
+    return; // Bloqueia movimento via drag and drop
+  }
+  // ... resto da lógica
+}, [onStatusChange, isAdmin]);
+```
+
+#### DragDropWrapper (`app/tickets/components/DragDropWrapper.tsx`):
+```typescript
+// Nova propriedade para desabilitar completamente
+interface DragDropWrapperProps {
+  disabled?: boolean; // NOVO
+}
+
+// Desabilita DnD quando disabled=true
+if (disabled) {
+  return <>{children}</>;
+}
+```
+
+#### DraggableTicket (`app/tickets/components/DragDropComponents.tsx`):
+```typescript
+// Desabilita listeners e muda cursor para não-admins
+{...(isAdmin ? listeners : {})}
+{...(isAdmin ? attributes : {})}
+className={cn(
+  'group relative transition-all duration-200',
+  isAdmin ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
+  isDragging && 'opacity-50 scale-105 shadow-lg z-50'
+)}
+
+// Botões de mudança rápida apenas para admins (já existia)
+{isAdmin && !isDragging && (
+  <div className="absolute top-2 right-2 hidden group-hover:flex gap-1">
+    {/* Botões de mudança de status */}
+  </div>
+)}
+```
+
+#### TicketModal (`app/tickets/components/TicketModal.tsx`):
+```typescript
+// Controles de status/prioridade apenas para admins (já existia)
+{isAdmin && (
+  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <Select value={ticket.status} onValueChange={handleStatusChange}>
+      {/* Controle de status */}
+    </Select>
+    <Select value={ticket.priority} onValueChange={handlePriorityChange}>
+      {/* Controle de prioridade */}  
+    </Select>
+  </div>
+)}
+```
+
+## 🎨 **Experiência do Usuário**
+
+### **Para Staff (Usuários Não-Admin):**
+- ✅ **Podem VER** todos os tickets de todos os hotéis
+- ✅ **Podem CRIAR** novos tickets  
+- ✅ **Podem COMENTAR** em qualquer ticket
+- ✅ **Podem ANEXAR** arquivos aos tickets
+- ❌ **Não podem ALTERAR STATUS** (Open → In Progress → Done)
+- ❌ **Não podem usar DRAG AND DROP** para mover tickets
+- ❌ **Não veem botões** de mudança rápida de status
+- 🔒 **Interface indica** claramente que é visualização
+
+### **Para Admin:**
+- ✅ **Controle total** - podem fazer tudo que staff faz
+- ✅ **Podem ALTERAR STATUS** via drag-and-drop e modais
+- ✅ **Podem ALTERAR PRIORIDADE** dos tickets
+- ✅ **Veem botões** de mudança rápida de status no hover
+- 🎯 **Interface completa** sem restrições
+
+## 🚀 **Benefícios da Implementação**
+
+### **Transparência Total:**
+- Todos veem o que está acontecendo na plataforma
+- Melhor visibilidade de problemas recorrentes
+- Staff pode acompanhar progresso sem precisar perguntar
+
+### **Colaboração Melhorada:**
+- Staff pode comentar e adicionar contexto em tickets de outros hotéis
+- Problemas similares entre hotéis ficam visíveis
+- Conhecimento compartilhado entre equipes
+
+### **Controle Administrativo:**
+- Admins mantêm controle total sobre workflow
+- Status dos tickets controlado centralmente
+- Evita mudanças acidentais por usuários inexperientes
+
+### **UX Intuitiva:**
+- Interface adapta visualmente baseada em permissões
+- Mensagens claras sobre limitações
+- Drag-and-drop desabilitado graciosamente para não-admins
+
+## 📊 **Fluxo de Uso Atual**
+
+1. **Qualquer usuário** acessa `/tickets`
+2. **Vê todos os tickets** de toda a plataforma
+3. **Pode criar** novos tickets com problemas/sugestões
+4. **Pode comentar** e interagir com qualquer ticket
+5. **Admin** pode alterar status via:
+   - Drag and drop entre colunas
+   - Botões de mudança rápida (hover)
+   - Modal detalhado com selects
+6. **Staff** vê interface adaptada sem controles de status
+
+## ✅ **Status da Implementação**
+- ✅ Backend: Permissões implementadas
+- ✅ Frontend: Interface adaptativa implementada  
+- ✅ UX: Mensagens informativas adicionadas
+- ✅ Segurança: Controle de acesso no servidor
+- ✅ Graceful degradation: Non-admins têm UX limpa
+
+Sistema agora está **global e colaborativo** mantendo **controle administrativo adequado**! 🎉

--- a/app/tickets/components/DragDropComponents.tsx
+++ b/app/tickets/components/DragDropComponents.tsx
@@ -77,10 +77,11 @@ export function DraggableTicket({
     <div
       ref={setNodeRef}
       style={style}
-      {...listeners}
-      {...attributes}
+      {...(isAdmin ? listeners : {})}
+      {...(isAdmin ? attributes : {})}
       className={cn(
-        'group relative transition-all duration-200 cursor-grab active:cursor-grabbing',
+        'group relative transition-all duration-200',
+        isAdmin ? 'cursor-grab active:cursor-grabbing' : 'cursor-default',
         isDragging && 'opacity-50 scale-105 shadow-lg z-50'
       )}
     >

--- a/app/tickets/components/DragDropWrapper.tsx
+++ b/app/tickets/components/DragDropWrapper.tsx
@@ -14,9 +14,10 @@ import {
 interface DragDropWrapperProps {
   onDragEnd: (event: DragEndEvent) => void;
   children: React.ReactNode;
+  disabled?: boolean;
 }
 
-export function DragDropWrapper({ onDragEnd, children }: DragDropWrapperProps) {
+export function DragDropWrapper({ onDragEnd, children, disabled = false }: DragDropWrapperProps) {
   const [mounted, setMounted] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
 
@@ -37,13 +38,21 @@ export function DragDropWrapper({ onDragEnd, children }: DragDropWrapperProps) {
   }
 
   const handleDragStart = (event: DragStartEvent) => {
+    if (disabled) return;
     setActiveId(event.active.id as string);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     setActiveId(null);
-    onDragEnd(event);
+    if (!disabled) {
+      onDragEnd(event);
+    }
   };
+
+  // Se disabled, apenas retornar os children sem DndContext
+  if (disabled) {
+    return <>{children}</>;
+  }
 
   return (
     <DndContext

--- a/app/tickets/components/TicketBoard.tsx
+++ b/app/tickets/components/TicketBoard.tsx
@@ -121,6 +121,11 @@ export function TicketBoard({
     
     if (!over) return;
     
+    // Apenas admins podem mover tickets via drag and drop
+    if (!isAdmin) {
+      return;
+    }
+    
     const sourceStatus = active.data.current?.status as TicketStatus;
     const targetStatus = over.id as TicketStatus;
     
@@ -129,7 +134,7 @@ export function TicketBoard({
     
     // Alterar status do ticket
     onStatusChange(active.id as string, targetStatus);
-  }, [onStatusChange]);
+  }, [onStatusChange, isAdmin]);
 
   // Calcular estatísticas
   const stats = {
@@ -149,7 +154,7 @@ export function TicketBoard({
   }
 
   return (
-    <DragDropWrapper onDragEnd={handleDragEnd}>
+    <DragDropWrapper onDragEnd={handleDragEnd} disabled={!isAdmin}>
       <div className="space-y-6">
       {/* Header com filtros e ações */}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -159,6 +164,7 @@ export function TicketBoard({
           </h1>
           <p className="text-muted-foreground">
             Gerencie problemas técnicos e solicitações da plataforma ExpiWish
+            {!isAdmin && " (Visualização - Somente admins podem alterar status)"}
           </p>
         </div>
 

--- a/lib/tickets-service.ts
+++ b/lib/tickets-service.ts
@@ -169,12 +169,8 @@ export const getTickets = async (
     
     // Aplicar filtros no cliente para evitar necessidade de índices
     tickets = tickets.filter(ticket => {
-      // Filtro para staff - só vê tickets do próprio hotel
-      if (currentUser.role === 'staff' && currentUser.hotelId) {
-        if (ticket.createdBy?.hotelId !== currentUser.hotelId) {
-          return false;
-        }
-      }
+      // REMOVIDO: Filtro para staff - agora todos podem ver todos os tickets
+      // Tickets são globais para melhor colaboração e transparência
       
       // Filtro de arquivados
       if (ticket.isArchived === true) {
@@ -281,6 +277,13 @@ export const updateTicket = async (
     const currentTicket = await getTicketById(id);
     if (!currentTicket) {
       throw new Error('Ticket não encontrado');
+    }
+    
+    // Verificar permissão para mudança de status - apenas admins podem alterar
+    if (updateData.status && updateData.status !== currentTicket.status) {
+      if (currentUser.role !== 'admin') {
+        throw new Error('Apenas administradores podem alterar o status dos tickets');
+      }
     }
     
     // Preparar dados de atualização
@@ -439,12 +442,8 @@ export const subscribeToTickets = (
       
       // Aplicar filtros no cliente
       tickets = tickets.filter(ticket => {
-        // Filtro para staff - só vê tickets do próprio hotel
-        if (currentUser.role === 'staff' && currentUser.hotelId) {
-          if (ticket.createdBy?.hotelId !== currentUser.hotelId) {
-            return false;
-          }
-        }
+        // REMOVIDO: Filtro para staff - agora todos podem ver todos os tickets
+        // Tickets são globais para melhor colaboração e transparência
         
         // Filtro de arquivados
         if (ticket.isArchived === true) {


### PR DESCRIPTION
Global Tickets: All users see all tickets, admins control status

Makes ticket system platform-wide for better collaboration while restricting status changes to admins only. UI adapts automatically based on permissions.
This pull request makes the ticket system global, allowing all users to view and create tickets across all hotels, while restricting status changes to administrators only. The backend now enforces these permissions, and the frontend adapts the user interface based on the user's role, providing a clear and intuitive experience for both admins and staff. Drag-and-drop and status controls are disabled for non-admins, ensuring proper workflow control and transparency.

**Backend: Global ticket visibility & admin-only status control**
- Removed hotel-based filtering for staff in `getTickets`, `subscribeToTickets`, allowing all users to see all tickets.
- Added permission check in `updateTicket` to restrict status changes to admins only.

**Frontend: Adaptive interface and feature restrictions**
- Updated `TicketBoard.tsx` to disable drag-and-drop for non-admins and show an informative message about viewing permissions. 
- Modified `DragDropWrapper.tsx` and `DraggableTicket` components to disable drag-and-drop functionality for non-admin users. 

**User experience improvements**
- Non-admin users can view, create, comment, and attach files to tickets, but cannot change status or move tickets. Admins retain full control, with all relevant UI elements and controls available to them.

These changes ensure a collaborative and transparent ticketing system, while maintaining strict administrative control over ticket workflow.